### PR TITLE
Add Mercurius::Testing::Result

### DIFF
--- a/lib/mercurius/testing.rb
+++ b/lib/mercurius/testing.rb
@@ -1,5 +1,6 @@
 require 'mercurius/testing/base'
 require 'mercurius/testing/delivery'
+require 'mercurius/testing/result'
 require 'mercurius/testing/service'
 
 APNS::Service.send :prepend, Mercurius::Testing::Service

--- a/lib/mercurius/testing/result.rb
+++ b/lib/mercurius/testing/result.rb
@@ -1,0 +1,28 @@
+module Mercurius
+  module Testing
+    class Result
+      attr_reader :responses
+
+      def initialize(notification)
+        @notification = notification
+        @responses = []
+      end
+
+      def success?
+        true
+      end
+
+      def process_response(*)
+      end
+
+      def failed_responses
+        []
+      end
+
+      def failed_device_tokens
+        []
+      end
+
+    end
+  end
+end

--- a/lib/mercurius/testing/service.rb
+++ b/lib/mercurius/testing/service.rb
@@ -4,6 +4,7 @@ module Mercurius
 
       def deliver(notification, *device_tokens)
         Mercurius::Testing::Base.deliveries << Mercurius::Testing::Delivery.new(notification, Array(device_tokens).flatten)
+        Mercurius::Testing::Result.new notification
       end
 
     end

--- a/spec/lib/testing_spec.rb
+++ b/spec/lib/testing_spec.rb
@@ -1,6 +1,6 @@
-require File.expand_path('../../../lib/mercurius/testing/service', __FILE__)
-require File.expand_path('../../../lib/mercurius/testing/base', __FILE__)
-require File.expand_path('../../../lib/mercurius/testing/delivery', __FILE__)
+%w(service base result delivery).each do |rb|
+  require File.expand_path("../../../lib/mercurius/testing/#{rb}", __FILE__)
+end
 
 describe 'Test mode' do
 
@@ -21,10 +21,11 @@ describe 'Test mode' do
     let(:message) { GCM::Notification.new(alert: 'Hey') }
 
     it 'returns the deliveries sent to GCM' do
-      service.deliver message, 'token123'
+      result = service.deliver message, 'token123'
       delivery = Mercurius::Testing::Base.deliveries[0]
       expect(delivery.device_tokens).to include 'token123'
       expect(delivery.notification.data).to eq Hash[alert: 'Hey']
+      expect(result).to be_a_kind_of Mercurius::Testing::Result
     end
   end
 
@@ -33,10 +34,11 @@ describe 'Test mode' do
     let(:message) { APNS::Notification.new(alert: 'Hey') }
 
     it 'returns the deliveries sent to APNS' do
-      service.deliver message, 'token123'
+      result = service.deliver message, 'token123'
       delivery = Mercurius::Testing::Base.deliveries[0]
       expect(delivery.device_tokens).to include 'token123'
       expect(delivery.notification.alert).to eq 'Hey'
+      expect(result).to be_a_kind_of Mercurius::Testing::Result
     end
   end
 


### PR DESCRIPTION
Matches interface of GCM::Result. I think we need an APNS::Result matching the same interface even though it won’t do anything really.