### PR TITLE
Handle canonical ids and add dry_run option for notifications

### DIFF
--- a/lib/mercurius/gcm/notification.rb
+++ b/lib/mercurius/gcm/notification.rb
@@ -2,14 +2,18 @@ module GCM
   class Notification
     include ActiveModel::Model
 
-    attr_accessor :data, :collapse_key, :time_to_live, :delay_while_idle
+    def self.special_attrs
+      [:collapse_key, :time_to_live, :delay_while_idle, :dry_run]
+    end
 
+    attr_accessor :data
+    attr_accessor *special_attrs
     # validate delay_while_idle is true/false
     # validate ttl is integer in seconds
 
     def initialize(attributes = {})
       @attributes = attributes
-      super data: @attributes.except(:collapse_key, :time_to_live, :delay_while_idle)
+      super @attributes.slice(*self.class.special_attrs).merge(data: @attributes.except(*self.class.special_attrs))
     end
 
     def to_h
@@ -17,7 +21,8 @@ module GCM
         data: data,
         collapse_key: collapse_key,
         time_to_live: time_to_live,
-        delay_while_idle: delay_while_idle
+        delay_while_idle: delay_while_idle,
+        dry_run: dry_run
       }
 
       hash.reject { |k, v| v.nil? }

--- a/lib/mercurius/gcm/response.rb
+++ b/lib/mercurius/gcm/response.rb
@@ -31,5 +31,19 @@ module GCM
     def failed?
       !success?
     end
+
+    def has_canonical_ids?
+      (response_body.canonical_ids || 0) > 0
+    end
+
+    def canonical_ids
+      response_body.results.map do |result|
+        result["registration_id"]
+      end
+    end
+
+    def response_body
+      @response_body ||= OpenStruct.new JSON.parse(response.body)
+    end
   end
 end

--- a/lib/mercurius/gcm/result.rb
+++ b/lib/mercurius/gcm/result.rb
@@ -23,5 +23,8 @@ module GCM
       @_failed_device_tokens ||= failed_responses.flat_map { |response| response.device_tokens }
     end
 
+    def has_canonical_ids?
+      responses.map{ |response| response.has_canonical_ids? }.reduce{ |carry, val| carry || val }
+    end
   end
 end

--- a/lib/mercurius/testing/result.rb
+++ b/lib/mercurius/testing/result.rb
@@ -23,6 +23,10 @@ module Mercurius
         []
       end
 
+      def has_canonical_ids?
+        false
+      end
+
     end
   end
 end

--- a/lib/mercurius/version.rb
+++ b/lib/mercurius/version.rb
@@ -1,3 +1,3 @@
 module Mercurius
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/spec/lib/gcm_notification_spec.rb
+++ b/spec/lib/gcm_notification_spec.rb
@@ -1,0 +1,17 @@
+describe GCM::Notification do
+  describe 'with attributes' do
+    it 'should extract special attributes from the hash and assign them' do
+      notification = GCM::Notification.new({ collapse_key: 'some_key', time_to_live: 123, delay_while_idle: true, dry_run: true })
+      expect(notification.collapse_key).to eq 'some_key'
+      expect(notification.time_to_live).to eq 123
+      expect(notification.delay_while_idle).to eq true
+      expect(notification.dry_run).to eq true
+    end
+
+    it 'should move other attributes to data' do
+      notification = GCM::Notification.new({ message: 'hello', dry_run: true})
+      expect(notification.dry_run).to eq true
+      expect(notification.data).to eq({ message: 'hello' })
+    end
+  end
+end

--- a/spec/lib/gcm_response_spec.rb
+++ b/spec/lib/gcm_response_spec.rb
@@ -1,0 +1,25 @@
+describe GCM::Response do
+  subject { GCM::Response.new nil, nil }
+
+  it 'has_canonical_ids? should return true if the response body has canonical ids' do
+    allow(subject).to receive(:response_body) { OpenStruct.new canonical_ids: 1 }
+    expect(subject.has_canonical_ids?).to be_truthy
+  end
+
+  it 'has_canonical_ids? should return false if the body has no canonical ids' do
+    allow(subject).to receive(:response_body) { OpenStruct.new success: 1 }
+    expect(subject.has_canonical_ids?).to be_falsy
+  end
+
+  it 'canonical_ids should return an array of registration ids' do
+    allow(subject).to receive(:response_body) { OpenStruct.new results: [{'registration_id' => '1234'}, {'registration_id' => '5678'}, {}] }
+    expect(subject.canonical_ids).to eq ['1234', '5678', nil]
+  end
+
+  it 'response_body should return an openstruct of the response.body' do
+    allow(subject).to receive(:response) { OpenStruct.new body: { one: 'two' }.to_json }
+    result = subject.response_body
+    expect(result).to be_a OpenStruct
+    expect(result.to_h).to eq({one: 'two'})
+  end
+end

--- a/spec/lib/gcm_result_spec.rb
+++ b/spec/lib/gcm_result_spec.rb
@@ -1,0 +1,13 @@
+describe GCM::Result do
+  subject { GCM::Result.new nil }
+
+  it 'has_canonical_ids? should return true if any responses have them' do
+    allow(subject).to receive(:responses) { [instance_double(GCM::Response, has_canonical_ids?: true), instance_double(GCM::Response, has_canonical_ids?: false)] }
+    expect(subject.has_canonical_ids?).to be_truthy
+  end
+
+  it 'otherwise, has_canonical_ids should return false' do
+    allow(subject).to receive(:responses) { [instance_double(GCM::Response, has_canonical_ids?: false), instance_double(GCM::Response, has_canonical_ids?: false)] }
+    expect(subject.has_canonical_ids?).to be_falsy
+  end
+end


### PR DESCRIPTION
One problem I ran into is that sometimes android push tokens change, so devices can get multiple pushes if both tokens are still on the server. For the older token, GCM sends back canonical id's to let you know what the new token is. I added some helper methods to assist in this.

I also added dry_run to GCM::Notification and refactored a bit so that the non-data attributes actually make it into the hash at the end.