### PR TITLE
Add deliver_topic method to GCM Service and bump version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 NEW_README.md
+*.sublime-*

--- a/lib/mercurius/gcm/notification.rb
+++ b/lib/mercurius/gcm/notification.rb
@@ -3,7 +3,7 @@ module GCM
     include ActiveModel::Model
 
     def self.special_attrs
-      [:collapse_key, :time_to_live, :delay_while_idle, :dry_run]
+      [:collapse_key, :time_to_live, :delay_while_idle, :dry_run, :notification]
     end
 
     attr_accessor :data
@@ -18,6 +18,7 @@ module GCM
 
     def to_h
       hash = {
+        notification: notification,
         data: data,
         collapse_key: collapse_key,
         time_to_live: time_to_live,
@@ -31,6 +32,5 @@ module GCM
     def ==(that)
       attributes == that.attributes
     end
-
   end
 end

--- a/lib/mercurius/gcm/service.rb
+++ b/lib/mercurius/gcm/service.rb
@@ -26,6 +26,12 @@ module GCM
       result
     end
 
+    def deliver_topic(notification, topic)
+      GCM::Result.new(notification).tap do |result|
+        result.process_response connection.write(notification.to_h.merge(to: topic)), [topic]
+      end
+    end
+
     private
 
       def too_many_retries?

--- a/lib/mercurius/testing/service.rb
+++ b/lib/mercurius/testing/service.rb
@@ -7,6 +7,11 @@ module Mercurius
         Mercurius::Testing::Result.new notification
       end
 
+      def deliver_topic(notification, topic)
+        Mercurius::Testing::Base.deliveries << Mercurius::Testing::Delivery.new(notification, [topic])
+        Mercurius::Testing::Result.new notification
+      end
+
     end
   end
 end

--- a/lib/mercurius/version.rb
+++ b/lib/mercurius/version.rb
@@ -1,3 +1,3 @@
 module Mercurius
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/spec/lib/gcm_service_spec.rb
+++ b/spec/lib/gcm_service_spec.rb
@@ -7,7 +7,7 @@ describe GCM::Service do
     expect(service.key).to eq GCM.key
   end
 
-  describe '#send' do
+  describe '#deliver' do
     before { stub_request :post, %r[android.googleapis.com/gcm/send] }
 
     it 'sends a single message' do
@@ -35,6 +35,17 @@ describe GCM::Service do
         with(body: { data: { alert: 'Hey' }, registration_ids: tokens.take(999) })
       expect(WebMock).to have_requested(:post, %r[android.googleapis.com/gcm/send]).
         with(body: { data: { alert: 'Hey' }, registration_ids: [tokens.last] })
+    end
+  end
+
+  describe '#deliver_topic' do
+    before { stub_request :post, %r[android.googleapis.com/gcm/send] }
+    let(:message) { { notification: { title: 'hello', body: 'world' } } }
+
+    it 'sends a notification to a topic' do
+      service.deliver_topic message, '/topics/global'
+      expect(WebMock).to have_requested(:post, %r[android.googleapis.com/gcm/send]).
+        with(body: message.merge(to: '/topics/global'))
     end
   end
 


### PR DESCRIPTION
Also added a notification special attribute for GCM::Notification, but I think the preferred way to use the GCM Service is just with a hash instead of the Notification class, which is essentially a hash that does magic.