### PR TITLE
Return tokens in the same order they were sent in the test connections

### DIFF
--- a/lib/mercurius/testing/gcm/successful_connection.rb
+++ b/lib/mercurius/testing/gcm/successful_connection.rb
@@ -10,7 +10,7 @@ module GCM
         'success' => tokens.size,
         'failure' => 0,
         'canonical_ids' => 0,
-        'results' => valid_token_json(tokens)
+        'results' => tokens.map { |token| valid_token_json(token) }
       }.to_json
 
       Mercurius::FakeResponse.new body: json, status: 200

--- a/lib/mercurius/testing/gcm/token_serializer.rb
+++ b/lib/mercurius/testing/gcm/token_serializer.rb
@@ -1,15 +1,11 @@
 module GCM
   module TokenSerializer
-    def valid_token_json(tokens)
-      tokens.map do |token|
-        { 'message_id' => SecureRandom.hex }
-      end
+    def valid_token_json(token)
+      { 'message_id' => SecureRandom.hex }
     end
 
-    def invalid_token_json(tokens, error)
-      tokens.map do |token|
-        { 'error' => error }
-      end
+    def invalid_token_json(token, error)
+      { 'error' => error }
     end
 
     def canonical_token_json(tokens, canonical_ids_map)

--- a/lib/mercurius/testing/gcm/unregistered_device_token_connection.rb
+++ b/lib/mercurius/testing/gcm/unregistered_device_token_connection.rb
@@ -7,19 +7,40 @@ module GCM
     end
 
     def write(json)
-      invalid, valid = json[:registration_ids].partition do |token|
-        @invalid_tokens.include? token
-      end
+      tokens = json[:registration_ids]
 
       json = {
         'multicast_id' => '123',
-        'success' => valid.size,
-        'failure' => invalid.size,
+        'success' => valid_tokens_count(tokens),
+        'failure' => invalid_tokens_count(tokens),
         'canonical_ids' => 0,
-        'results' => valid_token_json(valid).concat(invalid_token_json(invalid, 'NotRegistered'))
+        'results' => tokens.map do |token|
+          if valid? token
+            valid_token_json token
+          else
+            invalid_token_json token, 'NotRegistered'
+          end
+        end
       }.to_json
 
       Mercurius::FakeResponse.new body: json, status: 200
     end
+
+    private
+      def valid?(token)
+        !invalid? token
+      end
+
+      def invalid?(token)
+        @invalid_tokens.include?(token)
+      end
+
+      def valid_tokens_count(tokens)
+        tokens.count { |token| valid? token }
+      end
+
+      def invalid_tokens_count(tokens)
+        tokens.count { |token| invalid? token }
+      end
   end
 end

--- a/lib/mercurius/version.rb
+++ b/lib/mercurius/version.rb
@@ -1,3 +1,3 @@
 module Mercurius
-  VERSION = '0.1.10'
+  VERSION = '0.1.9'
 end

--- a/lib/mercurius/version.rb
+++ b/lib/mercurius/version.rb
@@ -1,3 +1,3 @@
 module Mercurius
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end

--- a/lib/mercurius/version.rb
+++ b/lib/mercurius/version.rb
@@ -1,3 +1,3 @@
 module Mercurius
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end

--- a/spec/lib/testing_spec.rb
+++ b/spec/lib/testing_spec.rb
@@ -20,7 +20,7 @@ describe 'Test mode' do
       end
 
       it 'Returns invalid device errors for the tokens provided' do
-        responses = service.deliver message, 'token123', 'token456'
+        responses = service.deliver message, 'token456', 'token123'
         expect(responses.results.failed.size).to eq 1
         expect(responses.results.failed[0].token).to eq 'token456'
         expect(responses.results.failed[0].error).to eq 'NotRegistered'


### PR DESCRIPTION
Previously the test connections would return valid tokens first, then invalid tokens. For tests to be accurate they need to be returned in the same order they were sent so the response matches GCM.